### PR TITLE
Fix sumtypes for Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
     - "2.7"
     - "3.6"
     - "3.7"
+    - "3.8"
+    - "3.9"
+    - "3.10"
     - "pypy"
 install:
     - pip install -r dev-requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="sumtypes",
-    version="0.1a5",
+    version="0.1a6",
     description="Algebraic types for Python (notably providing Sum Types, aka "
                 "Tagged Unions)",
     long_description=open('README.rst').read(),

--- a/sumtypes.py
+++ b/sumtypes.py
@@ -115,7 +115,7 @@ def _get_attrs(obj):
 
 
 def _get_constructors(klass):
-    for k, v in vars(klass).items():
+    for k, v in list(vars(klass).items()):
         if type(v) is _Constructor:
             yield k, v
 


### PR DESCRIPTION
Currently sumtypes doesn't work on Python 3.10. The `_get_constructor` function fails with a RuntimeError:

```
sumtypes.py:118: in _get_constructors
    for k, v in vars(klass).items():
E   RuntimeError: dictionary changed size during iteration
```

This is due to a change in `dict.items()`. https://docs.python.org/3/whatsnew/3.10.html#other-language-changes

Anyway the fix is just to wrap it in a list.